### PR TITLE
Don't print error content to stderr

### DIFF
--- a/semtk3/semtkclient.py
+++ b/semtk3/semtkclient.py
@@ -63,13 +63,8 @@ class SemTkClient(restclient.RestClient):
     def _check_record_process(self, content):
         ''' perform all checks on content through checking for table 
         '''
-        try:
-            self._check_status(content)
-        except Exception as e:
-            print >> sys.stderr, content["recordProcessResults"]["errorTable"]
-            raise e
-            
-        
+        self._check_status(content)
+
         if  "recordProcessResults" not in content.keys():
             self.raise_exception("Rest service did not record process results")
     


### PR DESCRIPTION
1. it's good if libraries don't write their errors to stderr to allow the application to control error processing
2. this line has a type error that causes an additional exception while handling exceptions

Fixes #1