### PR TITLE
Adam/expose get shacl results

### DIFF
--- a/semtk3/__init__.py
+++ b/semtk3/__init__.py
@@ -1286,9 +1286,15 @@ def load_ingestion_package(triple_store_url:str, triple_store_type:str, ingestio
     '''
     return __get_utility_client().exec_load_ingestion_package(triple_store_url, triple_store_type, ingestion_package_path, clear, default_model_graph, default_data_graph)
 
+def get_shacl_results(conn, shacl_ttl_path, severity):
+    '''
+    Evaluate SHACL constraints and return results
+    :param conn: a SemTK connection json string
+    :param shacl_ttl_path: path to a SHACL file in TTL format
+    :param severity: minimum severity filter: Info, Warning, Violation
+    '''
+    return __get_utility_client().exec_get_shacl_results(conn, shacl_ttl_path, severity)
 
-
-    
 ##############################
 def __get_fdc_cache_client():
     status_client = statusclient.StatusClient(__build_client_url(STATUS_HOST, STATUS_PORT))
@@ -1326,7 +1332,9 @@ def __get_nodegroup_client():
     return nodegroupclient.NodegroupClient(__build_client_url(NODEGROUP_HOST, NODEGROUP_PORT), status_client, results_client)
 
 def __get_utility_client():
-    return utilityclient.UtilityClient( __build_client_url(UTILITY_HOST, UTILITY_PORT))
+    status_client = statusclient.StatusClient(__build_client_url(STATUS_HOST, STATUS_PORT))
+    results_client = resultsclient.ResultsClient(__build_client_url(RESULTS_HOST, RESULTS_PORT))
+    return utilityclient.UtilityClient( __build_client_url(UTILITY_HOST, UTILITY_PORT), status_client, results_client)
 
 def __get_ingestion_client():
     status_client = statusclient.StatusClient(__build_client_url(STATUS_HOST, STATUS_PORT))

--- a/semtk3/semtkasyncclient.py
+++ b/semtk3/semtkasyncclient.py
@@ -127,12 +127,12 @@ class SemTkAsyncClient(semtkclient.SemTkClient):
         table = self.post_get_table_results(jobid)
         return table
     
-    def post_async_to_json_blob(self, endpoint, dataObj={}):
+    def post_async_to_json_blob(self, endpoint, dataObj={}, files=None):
         ''' 
             returns json
             raises errors otherwise
         '''
-        jobid = self.post_to_jobid(endpoint, dataObj)
+        jobid = self.post_to_jobid(endpoint, dataObj, files)
         semtk3_logger.debug("jobid:  " + jobid)
         self.poll_until_success(jobid)
         ret = self.post_get_json_blob_results(jobid)

--- a/semtk3/semtkclient.py
+++ b/semtk3/semtkclient.py
@@ -182,12 +182,12 @@ s        '''
 
         return record_process["recordsProcessed"]
     
-    def post_to_jobid(self, endpoint, dataObj={}):
+    def post_to_jobid(self, endpoint, dataObj={}, files=None):
         ''' 
             returns string jobid
             raises errors otherwise
         '''
-        simple_res = self.post_to_simple(endpoint, dataObj)
+        simple_res = self.post_to_simple(endpoint, dataObj, files)
         return self.get_simple_field_str(simple_res, SemTkClient.JOB_ID_KEY)
     
     def post_to_jobid_warnings(self, endpoint, dataObj={}):

--- a/semtk3/test/Animal-shacl.ttl
+++ b/semtk3/test/Animal-shacl.ttl
@@ -1,0 +1,17 @@
+###
+### SHACL for unit test
+### Accompanies the model/data in AnimalSubProps.owl
+###
+
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix animalsubprops: <http://AnimalSubProps#> .
+@prefix test: <http://test#> .
+
+### a shape that expects each cat to have at least two names (will produce violations, since each cat only has one name)
+test:CatHasAtLeastTwoNames
+	a sh:NodeShape;
+	sh:targetClass animalsubprops:Cat;
+	sh:property [
+		sh:path 		animalsubprops:name;
+		sh:minCount 	2;
+	];

--- a/semtk3/test/test1.py
+++ b/semtk3/test/test1.py
@@ -780,5 +780,11 @@ class TestSemtk3(unittest.TestCase):
                     response_str += str(line.decode())
                 self.assertTrue(response_str == "ERROR: This endpoint only accepts ingestion packages in zip file format")
 
+    def test_shacl(self):
+        self.clear_graph()
+        self.load_cats_and_dogs()
+        results = semtk3.get_shacl_results(TestSemtk3.conn_str, 'Animal-shacl.ttl', 'Info') # SHACL expects each cat to have at least 2 names     
+        self.assertEquals(len(results["reportEntries"]), 6)  # all 6 cats only have 1 name
+
 if __name__ == '__main__':
     unittest.main()

--- a/semtk3/utilityclient.py
+++ b/semtk3/utilityclient.py
@@ -14,16 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from . import semtkclient
+from . import semtkasyncclient
 from . import plotspecs
 import os.path
 
-class UtilityClient(semtkclient.SemTkClient):
+class UtilityClient(semtkasyncclient.SemTkAsyncClient):
    
-    def __init__(self, serverURL):
+    def __init__(self, serverURL, status_client=None, results_client=None):
         ''' serverURL string - e.g. http://machine:8099
         '''
-        semtkclient.SemTkClient.__init__(self, serverURL, "utility")
+        semtkasyncclient.SemTkAsyncClient.__init__(self, serverURL, "utility", status_client, results_client)
 
     
     def exec_process_plot_spec(self, plotSpec, table):
@@ -59,3 +59,22 @@ class UtilityClient(semtkclient.SemTkClient):
         }
 
         return self.post_to_stream("loadIngestionPackage", payload, files=files)
+
+    def exec_get_shacl_results(self, conn:str, shacl_ttl_path:str, severity:str):
+        '''
+        Evaluate SHACL constraints and return results
+        :param conn: a SemTK connection json string
+        :param shacl_ttl_path: path to a SHACL file in TTL format
+        :param severity: minimum severity filter: Info, Warning, Violation
+        '''
+
+        payload = {
+            "conn": conn,
+            "severity": severity
+        }
+
+        files = {
+            "shaclTtlFile": (os.path.basename(shacl_ttl_path), open(shacl_ttl_path, 'rb'))
+        }
+
+        return self.post_async_to_json_blob("getShaclResults", payload, files=files)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setuptools.setup(
     ],
     install_requires=[
         'requests',
-        'python-dateutil'
+        'python-dateutil',
+        'plotly'
     ],
     python_requires='>=3.6',
      entry_points={


### PR DESCRIPTION
This exposes getShaclResults so we can experiment with it in the cli. I tested it with the following command in the python3 REPL: 

`>>> result = semtk3.get_shacl_results('{"name":"Basket","domain":"","enableOwlImports":false,"model":[{"type":"fuseki","url":"http://127.0.0.1:3030/RACK","graph":"http://brandnew"}],"data":[{"type":"fuseki","url":"http://127.0.0.1:3030/RACK","graph":"http://brandnew"}]}', 'DeliveryBasketExample-shacl.ttl', 'Info')`

To support this change, we had to change UtilityClient from extending SemtkClient to SemtkAsyncClient. To verify that this change didn't break other uses of the UtilityClient, such as loadIngestionPackage, I ran the following command before and after these changes and ensured that the result was the same:

`rack manifest import /home/adamk/Downloads/turnstile-ingestion-package.zip`